### PR TITLE
Add support MC 26.x and fixes 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: TabCompleteFilter
+          path: build/libs/*.jar

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Clone this repository, then run the following command:
 
 [Spigot](https://www.spigotmc.org/) - [Paper](https://papermc.io/software/paper) - [Folia](https://papermc.io/software/folia)
 
-`1.13.x|1.14.x|1.16.x|1.17.x|1.18.x|1.19.x|1.20.x|1.21.x`
+`1.13.x|1.14.x|1.16.x|1.17.x|1.18.x|1.19.x|1.20.x|1.21.x|26.x`
 
 ## License
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "dev.lee.tcf"
-version = "1.3.0"
+version = "1.3.1"
 
 tasks.compileJava {
   options.release.set(16)

--- a/src/main/java/dev/lee/tcf/commands/TabCompletion.java
+++ b/src/main/java/dev/lee/tcf/commands/TabCompletion.java
@@ -19,7 +19,7 @@ public class TabCompletion implements TabCompleter {
       return StringUtil.copyPartialMatches(args[0], hasCommand, new ArrayList<>());
     } else {
       SubCommand subCommand = TabCompleteFilter.getInstance().getCommandManager().getSubCommand(args[0].toLowerCase());
-      if (sender.hasPermission(subCommand.getPermission())) return subCommand.onTabComplete(sender, args);
+      if (subCommand != null && sender.hasPermission(subCommand.getPermission())) return subCommand.onTabComplete(sender, args);
     }
     return new ArrayList<>();
   }

--- a/src/main/java/dev/lee/tcf/commands/subcommands/ListCMD.java
+++ b/src/main/java/dev/lee/tcf/commands/subcommands/ListCMD.java
@@ -67,7 +67,7 @@ public class ListCMD extends SubCommand {
     if (CoreUtil.isPositiveInt(pageString)) page = Integer.parseInt(pageString);
     int position = page * maxDisplayed + 1;
 
-    List<String> commandList = tabManager.getGroupCommands(group);
+    List<String> commandList = new ArrayList<>(tabManager.getGroupCommands(group));
     commandList.sort(String::compareToIgnoreCase);
 
     List<TextComponent> lines = new LinkedList<>();

--- a/src/main/java/dev/lee/tcf/files/FileManager.java
+++ b/src/main/java/dev/lee/tcf/files/FileManager.java
@@ -5,15 +5,12 @@ import java.util.logging.Level;
 
 import dev.lee.tcf.TabCompleteFilter;
 import dev.lee.tcf.data.CustomArgData;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 
 public class FileManager {
   protected final HashMap<String, CustomYML> ymlFiles = new HashMap<>();
-
-  public FileManager() {
-    Locale.setDefault(Locale.ENGLISH);
-  }
 
   public void createYML(String name) {
     ymlFiles.put(name, new CustomYML(name + ".yml", ""));
@@ -61,7 +58,9 @@ public class FileManager {
     CustomYML customYML = getYML("config");
     YamlConfiguration yaml = customYML.getFile();
 
-    for (String key : yaml.getConfigurationSection("groups").getKeys(false)) {
+    ConfigurationSection groupsSection = yaml.getConfigurationSection("groups");
+    if (groupsSection == null) return groupData;
+    for (String key : groupsSection.getKeys(false)) {
       try {
         groupData.put(key, yaml.getStringList("groups." + key));
       } catch (Exception e) {
@@ -76,14 +75,18 @@ public class FileManager {
     CustomYML customYML = getYML("args");
     YamlConfiguration yaml = customYML.getFile();
 
-    for (String key : yaml.getConfigurationSection("custom-args").getKeys(false)) {
+    ConfigurationSection customArgsSection = yaml.getConfigurationSection("custom-args");
+    if (customArgsSection == null) return argData;
+    for (String key : customArgsSection.getKeys(false)) {
       try {
         String base = "custom-args." + key;
         boolean permissionCheck = yaml.getBoolean(base + ".permission-check");
         String permission = yaml.getString(base + ".permission");
         String command = yaml.getString(base + ".command");
         Map<Integer, List<String>> args = new HashMap<>();
-        for (String argKey : yaml.getConfigurationSection(base + ".args").getKeys(false)) {
+        ConfigurationSection argsSection = yaml.getConfigurationSection(base + ".args");
+        if (argsSection == null) continue;
+        for (String argKey : argsSection.getKeys(false)) {
           int number = Integer.parseInt(argKey);
           List<String> numberArgs = yaml.getStringList(base + ".args." + argKey);
           args.put(number, numberArgs);

--- a/src/main/java/dev/lee/tcf/files/files/Lang.java
+++ b/src/main/java/dev/lee/tcf/files/files/Lang.java
@@ -56,7 +56,7 @@ public enum Lang {
     String text = getString();
     if (variables == null || variables.length == 0) return text;
     for (int i = 0; i < variables.length; i++) text = text.replace("{" + i + "}", variables[i]);
-    return CoreUtil.parseColor(text);
+    return text;
   }
 
   public TextComponent getTextComponent() {

--- a/src/main/java/dev/lee/tcf/util/CoreUtil.java
+++ b/src/main/java/dev/lee/tcf/util/CoreUtil.java
@@ -16,7 +16,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class CoreUtil {
-  private final static int mcVersion = Integer.parseInt(getMajorVersion(Bukkit.getVersion()).substring(2));
+  private final static int mcVersion = resolveMinorVersion();
   private final static Pattern hexPattern = Pattern.compile("\\&#[a-fA-F0-9]{6}");
 
   public static String parseColor(String text) {
@@ -32,18 +32,17 @@ public class CoreUtil {
     return ChatColor.translateAlternateColorCodes('&', text);
   }
 
-  private static String getMajorVersion(String version) {
-    if (version == null) return null;
-    int index = version.lastIndexOf("MC:");
-    if (index != -1) {
-      version = version.substring(index + 4, version.length() - 1);
-    } else if (version.endsWith("SNAPSHOT")) {
-      index = version.indexOf('-');
-      version = version.substring(0, index);
+  private static int resolveMinorVersion() {
+    String bukkitVersion = Bukkit.getBukkitVersion();
+    if (bukkitVersion == null) return 0;
+    String mcVersion = bukkitVersion.split("-")[0];
+    String[] parts = mcVersion.split("\\.");
+    if (parts.length < 2) return 0;
+    try {
+      return Integer.parseInt(parts[1]);
+    } catch (NumberFormatException e) {
+      return 0;
     }
-    int lastDot = version.lastIndexOf('.');
-    if (version.indexOf('.') != lastDot) version = version.substring(0, lastDot);
-    return version;
   }
 
   public static boolean isSupported(int version) {


### PR DESCRIPTION
Hi, @LeeTheTech 

The plugin parsed `Bukkit.getVersion()` to figure out the Minecraft version, assuming the vanilla `... (MC: x.y.z)` shape. Forks like Leaf return a different string, so the parser ended up with a non-numeric value and `Integer.parseInt` threw while `CoreUtil` was still initializing. After that first failure the class stayed uninitialized, and every command that touches it (color parsing, `/tcf reload`, all messages) died with `NoClassDefFoundError`.

This switches detection to `Bukkit.getBukkitVersion()`, which always returns the canonical `1.21.4-R0.1-SNAPSHOT` form no matter the fork, and falls back to `0` instead of crashing if the format is ever unexpected.
